### PR TITLE
feat: 新增配置useGlobalCache，复杂项目多次进入mpNpm时可共享缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ const wxss = () => gulp.src('src/**/*.wxss')
 默认情况插件只会按需提取的依赖与组件，可通过该属性指定包名对整个包进行完整提取，主要用于提取分析不到的依赖。\
 例如设置 `options.fullExtract = ['weui-miniprogram']` 表示整个 `weui-miniprogram` 包及时未使用到也会被全量提取
 
+#### options.useGlobalCache
+
+类型: `Boolean`\
+默认值: `false`
+
+默认情况下，对于较复杂的项目会根据不同文件类型，创建多个mpNpm实例
+1、x个实例就会重复执行x次fullExtract插件的逻辑
+2、gulp.watch时，任何一个文件变更都会触发fullExtract
+3、extracted解析标记在实例结束后会清理，watch文件时，每次文件变更会重新解析，耗时较长
+
+例如设置 `options.useGlobalCache = true` 表示多个实例共享初始化和依赖解析缓存，会大幅提高watch时的性能。建议大量页面使用npm包的项目开启。
 
 ## 特点
 

--- a/index.js
+++ b/index.js
@@ -24,20 +24,27 @@ let pkgList = {};
 const mpPkgMathMap = {};
 // 项目初始化缓存 (一个项目只初始化一次)
 let projectInitCache = null;
-
+// 复杂项目多次进入mpNpm时可共享缓存
+const globalCache = {
+    // 多实例只初始化一次
+    instanceInitCache: false,
+    // 多实例共享依赖文件解析
+    extracted: {}
+}
 /**
  * gulp-mp-npm
  */
 module.exports = function mpNpm(options = {}) {
     const npmDirname = options.npmDirname || defaultNpmDirname;
+    const useGlobalCache = options.useGlobalCache
     let fullExtract = options.fullExtract || [];
     if (!Array.isArray(fullExtract)) fullExtract = [fullExtract];
 
     // 插件实例初始化缓存 (一次插件调用初始化一次)
-    let instanceInitCache = null;
+    let instanceInitCache = useGlobalCache ? globalCache.instanceInitCache : null;
 
     // 已提取的包文件夹路径
-    const extracted = {};
+    const extracted = useGlobalCache ? globalCache.extracted : {};
 
     /** init
      * 初始化
@@ -110,6 +117,7 @@ module.exports = function mpNpm(options = {}) {
                             .on('error', reject));
                     }));
                 })();
+                if(useGlobalCache) globalCache.instanceInitCache = instanceInitCache;
             }
             await instanceInitCache;
             next(null, file);


### PR DESCRIPTION
一般项目会根据不同文件类型，创建多个mpNpm实例，常见问题如下
1、x个实例就会重复执行x次fullExtract插件的逻辑，其实是没必要的
2、gulp.watch时，任何一个文件变更都会触发fullExtract，其实是没必要的
3、extracted解析标记在实例结束后会清理，watch文件时，每次文件变更会重新解析，耗时较长

开启useGlobalCache会复用第一次构建时的缓存，会大幅降低gulp.watch的耗时，至少60%。对于重度引用npm的复杂应用来说，原来每次保存文件耗时高达2s+，启用后大概0.8s+。

```js
 {
   // 默认为false，不影响现有逻辑
    useGlobalCache: true,
  }
```